### PR TITLE
added metaplex python api submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "gatekeeper"]
 	path = gatekeeper
 	url = https://github.com/cnp0/gatekeeper
+[submodule "metaplex-api"]
+	path = metaplex-api
+	url = https://github.com/cnp0/metaplex-api


### PR DESCRIPTION
Prototyping any minting using the python api. We can replace this with something more robust if we want to move forward with metaplex.